### PR TITLE
Modify functionality of text fields

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -6,6 +6,7 @@
         <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
         <option name="gradleHome" value="$APPLICATION_HOME_DIR$/gradle/gradle-2.4" />
+        <option name="gradleJvm" value="1.8" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />
@@ -16,4 +17,3 @@
     </option>
   </component>
 </project>
-

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -44,4 +44,3 @@
     <option name="id" value="Android" />
   </component>
 </project>
-

--- a/SimpleTodo.iml
+++ b/SimpleTodo.iml
@@ -4,10 +4,11 @@
     <facet type="java-gradle" name="Java-Gradle">
       <configuration>
         <option name="BUILD_FOLDER_PATH" value="$MODULE_DIR$/build" />
+        <option name="BUILDABLE" value="false" />
       </configuration>
     </facet>
   </component>
-  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7" inherit-compiler-output="false">
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7" inherit-compiler-output="true">
     <output url="file://$MODULE_DIR$/build/classes/main" />
     <output-test url="file://$MODULE_DIR$/build/classes/test" />
     <exclude-output />
@@ -18,4 +19,3 @@
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
 </module>
-

--- a/app/app.iml
+++ b/app/app.iml
@@ -9,11 +9,15 @@
     <facet type="android" name="Android">
       <configuration>
         <option name="SELECTED_BUILD_VARIANT" value="debug" />
+        <option name="SELECTED_TEST_ARTIFACT" value="_android_test_" />
         <option name="ASSEMBLE_TASK_NAME" value="assembleDebug" />
         <option name="COMPILE_JAVA_TASK_NAME" value="compileDebugSources" />
         <option name="ASSEMBLE_TEST_TASK_NAME" value="assembleDebugAndroidTest" />
-        <option name="SOURCE_GEN_TASK_NAME" value="generateDebugSources" />
-        <option name="TEST_SOURCE_GEN_TASK_NAME" value="generateDebugAndroidTestSources" />
+        <option name="COMPILE_JAVA_TEST_TASK_NAME" value="compileDebugAndroidTestSources" />
+        <afterSyncTasks>
+          <task>generateDebugAndroidTestSources</task>
+          <task>generateDebugSources</task>
+        </afterSyncTasks>
         <option name="ALLOW_USER_CONFIGURATION" value="false" />
         <option name="MANIFEST_FILE_RELATIVE_PATH" value="/src/main/AndroidManifest.xml" />
         <option name="RES_FOLDER_RELATIVE_PATH" value="/src/main/res" />
@@ -67,6 +71,8 @@
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/dependency-cache" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/dex" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/dex-cache" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/appcompat-v7/23.0.1/jars" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/support-v4/23.0.1/jars" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/jacoco" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/javaResources" />
@@ -90,4 +96,3 @@
     <orderEntry type="library" exported="" name="support-annotations-23.0.1" level="project" />
   </component>
 </module>
-

--- a/app/src/main/java/com/calvinlsliang/simpletodo/EditItemActivity.java
+++ b/app/src/main/java/com/calvinlsliang/simpletodo/EditItemActivity.java
@@ -4,14 +4,18 @@ import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
+import android.view.KeyEvent;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
+import android.view.inputmethod.EditorInfo;
+import android.view.inputmethod.InputMethodManager;
 import android.widget.EditText;
+import android.widget.TextView;
 
 public class EditItemActivity extends AppCompatActivity {
 
-
+    private EditText etNewItem;
     public static final String ITEM = "item";
     public static final String POS = "pos";
     public static final String ID = "id";
@@ -26,10 +30,23 @@ public class EditItemActivity extends AppCompatActivity {
         pos = getIntent().getIntExtra(POS, 0);
         int id = getIntent().getIntExtra(ID, 0);
 
-        EditText etNewItem = (EditText) findViewById(R.id.eiEditText);
+        etNewItem = (EditText) findViewById(R.id.eiEditText);
         etNewItem.setText(item.toString());
         etNewItem.setSelection(etNewItem.getText().length());
+        setupListeners();
+    }
 
+    public void setupListeners() {
+        etNewItem.setOnEditorActionListener(new TextView.OnEditorActionListener() {
+            @Override
+            public boolean onEditorAction(TextView v, int actionId, KeyEvent event) {
+                if (actionId == EditorInfo.IME_ACTION_DONE) {
+                    hideSoftKeyboard();
+                    return true;
+                }
+                return false;
+            }
+        });
     }
 
     @Override
@@ -62,6 +79,12 @@ public class EditItemActivity extends AppCompatActivity {
 
         setResult(Activity.RESULT_OK, data);
         finish();
+    }
 
+    public void hideSoftKeyboard() {
+        if (getCurrentFocus() != null) {
+            InputMethodManager inputMethodManager = (InputMethodManager) getSystemService(INPUT_METHOD_SERVICE);
+            inputMethodManager.hideSoftInputFromWindow(getCurrentFocus().getWindowToken(), 0);
+        }
     }
 }

--- a/app/src/main/java/com/calvinlsliang/simpletodo/MainActivity.java
+++ b/app/src/main/java/com/calvinlsliang/simpletodo/MainActivity.java
@@ -4,13 +4,16 @@ import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
-import android.view.Menu;
+import android.view.KeyEvent;
 import android.view.MenuItem;
 import android.view.View;
+import android.view.inputmethod.EditorInfo;
+import android.view.inputmethod.InputMethodManager;
 import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
 import android.widget.EditText;
 import android.widget.ListView;
+import android.widget.TextView;
 
 import org.apache.commons.io.FileUtils;
 
@@ -23,6 +26,7 @@ public class MainActivity extends AppCompatActivity {
     private ArrayList<String> items;
     private ArrayAdapter<String> itemsAdapter;
     private ListView lvItems;
+    private EditText etNewText;
     private final int REQUEST_CODE = 20;
     public static final String ITEM = "item";
     public static final String POS = "pos";
@@ -33,15 +37,15 @@ public class MainActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
-
         lvItems = (ListView) findViewById(R.id.lvListView);
+        etNewText = (EditText) findViewById(R.id.etNewItem);
         readItems();
         itemsAdapter = new ArrayAdapter<String>(this, android.R.layout.simple_list_item_1, items);
         lvItems.setAdapter(itemsAdapter);
-        setupListViewListener();
+        setupListeners();
     }
 
-    public void setupListViewListener() {
+    public void setupListeners() {
         lvItems.setOnItemLongClickListener(
             new AdapterView.OnItemLongClickListener() {
                 @Override
@@ -65,6 +69,21 @@ public class MainActivity extends AppCompatActivity {
                 }
             }
         );
+
+        etNewText.setOnEditorActionListener(new TextView.OnEditorActionListener() {
+            @Override
+            public boolean onEditorAction(TextView v, int actionId, KeyEvent event) {
+                if (actionId == EditorInfo.IME_ACTION_DONE) {
+                    String itemText = etNewText.getText().toString();
+                    itemsAdapter.add(itemText);
+                    etNewText.setText("");
+                    writeItems();
+                    hideSoftKeyboard();
+                    return true;
+                }
+                return false;
+            }
+        });
     }
 
     private void launchEditItem(String item, int pos, long id) {
@@ -73,6 +92,13 @@ public class MainActivity extends AppCompatActivity {
         i.putExtra(POS, pos);
         i.putExtra(ID, id);
         startActivityForResult(i, REQUEST_CODE);
+    }
+
+    public void hideSoftKeyboard() {
+        if (getCurrentFocus() != null) {
+            InputMethodManager inputMethodManager = (InputMethodManager) getSystemService(INPUT_METHOD_SERVICE);
+            inputMethodManager.hideSoftInputFromWindow(getCurrentFocus().getWindowToken(), 0);
+        }
     }
 
     @Override
@@ -106,12 +132,12 @@ public class MainActivity extends AppCompatActivity {
         }
     }
 
-    @Override
-    public boolean onCreateOptionsMenu(Menu menu) {
-        // Inflate the menu; this adds items to the action bar if it is present.
-        getMenuInflater().inflate(R.menu.menu_main, menu);
-        return true;
-    }
+//    @Override
+//    public boolean onCreateOptionsMenu(Menu menu) {
+//        // Inflate the menu; this adds items to the action bar if it is present.
+//        getMenuInflater().inflate(R.menu.menu_main, menu);
+//        return true;
+//    }
 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {

--- a/app/src/main/res/layout/activity_edit_item.xml
+++ b/app/src/main/res/layout/activity_edit_item.xml
@@ -11,24 +11,27 @@
     <TextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="@string/edit_item_below"
+        android:text="@string/edit_title"
         android:id="@+id/eibTextView"
-        android:textSize="40dp"
+        android:textSize="30sp"
         android:layout_alignParentTop="true"
         android:layout_alignParentLeft="true"
-        android:layout_alignParentStart="true" />
+        android:layout_alignParentStart="true"
+        android:layout_alignRight="@+id/eiEditText"
+        android:layout_alignEnd="@+id/eiEditText" />
 
     <EditText
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:id="@+id/eiEditText"
+        android:imeOptions="actionDone"
+        android:hint="@string/edit_title_hint"
         android:layout_below="@+id/eibTextView"
         android:layout_alignParentLeft="true"
         android:layout_alignParentStart="true"
-        android:layout_marginTop="49dp"
-        android:layout_alignRight="@+id/eibTextView"
-        android:layout_alignEnd="@+id/eibTextView"
-        android:hint="@string/edit_text_hint" />
+        android:layout_alignParentRight="true"
+        android:layout_alignParentEnd="true"
+        android:singleLine="true" />
 
     <Button
         android:layout_width="wrap_content"
@@ -36,8 +39,22 @@
         android:text="@string/save"
         android:id="@+id/saveButton"
         android:onClick="onSave"
-        android:layout_below="@+id/eiEditText"
+        android:layout_alignParentBottom="true"
         android:layout_alignParentLeft="true"
         android:layout_alignParentStart="true"
-        android:layout_marginTop="35dp" />
+        android:layout_alignParentRight="true"
+        android:layout_alignParentEnd="true" />
+
+    <!--<TextView-->
+        <!--android:layout_width="wrap_content"-->
+        <!--android:layout_height="wrap_content"-->
+        <!--android:text="@string/edit_description"-->
+        <!--android:id="@+id/textView"-->
+        <!--android:layout_below="@+id/eiEditText"-->
+        <!--android:layout_alignParentLeft="true"-->
+        <!--android:layout_alignParentStart="true"-->
+        <!--android:layout_marginTop="37dp"-->
+        <!--android:layout_alignRight="@+id/eiEditText"-->
+        <!--android:layout_alignEnd="@+id/eiEditText"-->
+        <!--android:textSize="30sp" />-->
 </RelativeLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -10,7 +10,7 @@
     <Button
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Add Item"
+        android:text="@string/main_add_item"
         android:id="@+id/btnAddItem"
         android:onClick="onAddItem"
         android:layout_alignParentBottom="true"
@@ -27,13 +27,15 @@
         android:layout_above="@+id/btnAddItem" />
 
     <EditText
+        android:hint="@string/main_enter_text_hint"
+        android:id="@+id/etNewItem"
+        android:imeOptions="actionDone"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:id="@+id/etNewItem"
         android:layout_below="@+id/lvListView"
         android:layout_alignParentLeft="true"
         android:layout_alignParentStart="true"
         android:layout_toLeftOf="@+id/btnAddItem"
         android:layout_toStartOf="@+id/btnAddItem"
-        android:hint="Enter Text Here" />
+        android:singleLine="true" />
 </RelativeLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,7 +4,12 @@
     <string name="action_settings">Settings</string>
     <string name="title_activity_edit_item">EditItemActivity</string>
 
-    <string name="edit_item_below">Edit Item Below:</string>
-    <string name="edit_text_hint">Enter Text</string>
+    <string name="main_add_item">Add Item</string>
+    <string name="main_enter_text_hint">Enter Text Here</string>
+
+    <string name="edit_title">Edit Title</string>
+    <string name="edit_title_hint">Enter Title</string>
+    <string name="edit_description">Edit Description</string>
+
     <string name="save">Save</string>
 </resources>


### PR DESCRIPTION
##### Use case

Since these are short todos, it doesn't make sense to allow more than one line for todo. Currently the behavior of pressing done/enter will create a newline so the user has to close the keyboard and then press "Add Item" or "Save".
##### Changes

Cap the todo at one line so when the user presses done the item is automatically saved and the keyboard is closed.

For the edit page, the keyboard is just closed and the user has to press save still. This functionality is kept this way because descriptions will be added in a future release.
##### Future work

For cases where there are longer todos, I am working on a description field where users will be able to add lengthier descriptions to their todos.
##### Screenshots

![Video Walkthrough](http://i.imgur.com/RnAPzn2.gif)
